### PR TITLE
feat: tweak numbers to feel more like overcooked

### DIFF
--- a/DashPing/DashMenu.cs
+++ b/DashPing/DashMenu.cs
@@ -11,21 +11,35 @@ namespace KitchenDashPing {
         private static readonly List<bool> showMarkerValues = new List<bool> { true, false };
         private static readonly List<string> showMarkerLabels = new List<string> { "Show", "Hide" };
 
+        private static readonly List<bool> holdButtonValues = new List<bool> { false, true };
+        private static readonly List<string> holdButtonLabels = new List<string> { "Press Only", "Press or Hold" };
+
         public DashMenu(Transform container, ModuleList module_list) : base(container, module_list) { }
 
         public override void Setup(int player_id) {
-            Option<bool> option = new Option<bool>(showMarkerValues, DashPreferences.isShowMarker(), showMarkerLabels);
+            Option<bool> showMarkerOption = new Option<bool>(showMarkerValues, DashPreferences.isShowMarker(), showMarkerLabels);
+            Option<bool> holdButtonOption = new Option<bool>(holdButtonValues, DashPreferences.isHoldButton(), holdButtonLabels);
 
             AddLabel("Markers");
             AddInfo("Show the ping marker when dashing");
-            AddSelect(option);
+            AddSelect(showMarkerOption);
             AddInfo("This setting only works when you are the host, and affects everyone");
+            New<SpacerElement>();
+
+            AddLabel("Controls");
+            AddInfo("Hold dash button to dash repeatedly");
+            AddSelect(holdButtonOption);
+            AddInfo("In online multiplayer, 'Press Only' can make dashing unreliable. Choose 'Press or Hold' when you are not the host");
             New<SpacerElement>();
             New<SpacerElement>();
             AddButton(Localisation["MENU_BACK_SETTINGS"], delegate { RequestPreviousMenu(); });
 
-            option.OnChanged += delegate (object _, bool value) {
+            showMarkerOption.OnChanged += delegate (object _, bool value) {
                 DashPreferences.setShowMarker(value);
+            };
+
+            holdButtonOption.OnChanged += delegate (object _, bool value) {
+                DashPreferences.setHoldButton(value);
             };
         }
     }

--- a/DashPing/DashPreferences.cs
+++ b/DashPing/DashPreferences.cs
@@ -5,9 +5,11 @@ namespace KitchenDashPing {
     public class DashPreferences {
 
         private static Pref ShowMarkerPref = new Pref(DashSystem.MOD_ID, nameof(ShowMarkerPref));
+        private static Pref HoldButtonPref = new Pref(DashSystem.MOD_ID, nameof(HoldButtonPref));
 
         public static void registerPreferences() {
             Preferences.AddPreference<bool>(new BoolPreference(ShowMarkerPref, true));
+            Preferences.AddPreference<bool>(new BoolPreference(HoldButtonPref, false));
             Preferences.Load();
         }
 
@@ -17,6 +19,14 @@ namespace KitchenDashPing {
 
         public static void setShowMarker(bool value) {
             Preferences.Set<bool>(ShowMarkerPref, value);
+        }
+
+        public static bool isHoldButton() {
+            return Preferences.Get<bool>(HoldButtonPref);
+        }
+
+        public static void setHoldButton(bool value) {
+            Preferences.Set<bool>(HoldButtonPref, value);
         }
     }
 }

--- a/DashPing/Main.cs
+++ b/DashPing/Main.cs
@@ -19,7 +19,7 @@ namespace KitchenDashPing {
 
         private const float INITIAL_SPEED = 3000f;
         private const float DASH_SPEED = 12000f;
-        private const float DASH_OVERALL_COOLDOWN = 1.25f;
+        private const float DASH_OVERALL_COOLDOWN = 0.9f;
         private const float DASH_REDUCE_PER_UPDATE = 0.03125f;
         private const float DASH_DURATION = DASH_REDUCE_PER_UPDATE * 10;
 
@@ -85,7 +85,8 @@ namespace KitchenDashPing {
             PlayerView.ViewData viewData = (PlayerView.ViewData)fieldInfo.GetValue(player);
             ButtonState buttonState = viewData.Inputs.State.SecondaryAction2;
 
-            return buttonState == ButtonState.Pressed;
+            // if the HoldButton option is used, a held dash button is allowed as well
+            return buttonState == ButtonState.Pressed || (DashPreferences.isHoldButton() == true && buttonState == ButtonState.Held);
         }
 
         private void returnSpeedToNormal(int playerId) {

--- a/DashPing/Main.cs
+++ b/DashPing/Main.cs
@@ -18,10 +18,10 @@ namespace KitchenDashPing {
         public const string MOD_VERSION = "0.1.8";
 
         private const float INITIAL_SPEED = 3000f;
-        private const float DASH_SPEED = 6000f;
-        private const float DASH_OVERALL_COOLDOWN = 0.75f;
-        private const float DASH_DURATION = 0.35f;
+        private const float DASH_SPEED = 12000f;
+        private const float DASH_OVERALL_COOLDOWN = 1.25f;
         private const float DASH_REDUCE_PER_UPDATE = 0.03125f;
+        private const float DASH_DURATION = DASH_REDUCE_PER_UPDATE * 10;
 
         private Dictionary<int, DashStatus> statuses = new Dictionary<int, DashStatus>();
         public static bool isRegistered = false;
@@ -85,10 +85,7 @@ namespace KitchenDashPing {
             PlayerView.ViewData viewData = (PlayerView.ViewData)fieldInfo.GetValue(player);
             ButtonState buttonState = viewData.Inputs.State.SecondaryAction2;
 
-            return buttonState == ButtonState.Pressed ||
-                buttonState == ButtonState.Held ||
-                buttonState == ButtonState.Released ||
-                buttonState == ButtonState.Consumed;
+            return buttonState == ButtonState.Pressed;
         }
 
         private void returnSpeedToNormal(int playerId) {


### PR DESCRIPTION
Hey there :)
Just a suggested tweaking of your values to make it feel more like overcooked (in my opinion).
I'm really glad you made this mod, since my partner and I recently started playing PlateUp after an obsession with Overcooked, and especially my partner really missed the dash, because it was so ingrained in their muscle memory from the other game x)

But after trying your mod, it felt to me like there could be some work done to make it feel more like the dash in overcooked. For one thing, you can't hold the button down in overcooked, you have to press it repeatedly, and it has a slightly longer cooldown, but it basically catapults you forward when you do so.
So I changed your event handler to only accept single button presses and changed the speed boost to be one big boost that jumps you ahead, but stops again very shortly.

I even tried to find a way to actually throw the player forward (even when standing, like in overcooked), but I could not figure out how. You can basically teleport the player, but I couldn't find a way to force a forward movement.